### PR TITLE
feat: enable backpressure handling in streams

### DIFF
--- a/protocols/stream/src/control.rs
+++ b/protocols/stream/src/control.rs
@@ -73,6 +73,17 @@ impl Control {
     ) -> Result<IncomingStreams, AlreadyRegistered> {
         Shared::lock(&self.shared).accept(protocol)
     }
+
+    /// Accept inbound streams for the provided protocol with a limit.
+    ///
+    /// To stop accepting streams, simply drop the returned [`IncomingStreams`] handle.
+    pub fn accept_with_limit(
+        &mut self,
+        protocol: StreamProtocol,
+        limit: Option<usize>,
+    ) -> Result<IncomingStreams, AlreadyRegistered> {
+        Shared::lock(&self.shared).accept_with_limit(protocol, limit)
+    }
 }
 
 /// Errors while opening a new stream.
@@ -113,15 +124,76 @@ impl std::error::Error for OpenStreamError {
     }
 }
 
+/// Enum to wrap [`mpsc::Sender`] and [`mpsc::UnboundedSender`]
+pub(crate) enum InboundSender {
+    Bounded(mpsc::Sender<(PeerId, Stream)>),
+    Unbounded(mpsc::UnboundedSender<(PeerId, Stream)>),
+}
+
+impl InboundSender {
+    pub(crate) fn is_closed(&self) -> bool {
+        match self {
+            InboundSender::Bounded(s) => s.is_closed(),
+            InboundSender::Unbounded(s) => s.is_closed(),
+        }
+    }
+
+    pub(crate) fn try_send(&mut self, item: (PeerId, Stream)) -> TrySendResult {
+        match self {
+            InboundSender::Bounded(s) => match s.try_send(item) {
+                Ok(()) => TrySendResult::Ok,
+                Err(e) if e.is_full() => TrySendResult::Full,
+                Err(e) if e.is_disconnected() => TrySendResult::Disconnected,
+                _ => unreachable!(),
+            },
+            InboundSender::Unbounded(s) => match s.unbounded_send(item) {
+                Ok(()) => TrySendResult::Ok,
+                Err(_e) => TrySendResult::Disconnected,
+            },
+        }
+    }
+}
+
+/// Enum to wrap [`mpsc::Receiver`] and [`mpsc::UnboundedReceiver`]
+pub(crate) enum InboundReceiver {
+    Bounded(mpsc::Receiver<(PeerId, Stream)>),
+    Unbounded(mpsc::UnboundedReceiver<(PeerId, Stream)>),
+}
+
+impl futures::Stream for InboundReceiver {
+    type Item = (PeerId, Stream);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match &mut *self {
+            InboundReceiver::Bounded(s) => Pin::new(s).poll_next_unpin(cx),
+            InboundReceiver::Unbounded(s) => Pin::new(s).poll_next_unpin(cx),
+        }
+    }
+}
+
+pub(crate) enum TrySendResult {
+    Ok,
+    Full,
+    Disconnected,
+}
+
 /// A handle to inbound streams for a particular protocol.
 #[must_use = "Streams do nothing unless polled."]
 pub struct IncomingStreams {
-    receiver: mpsc::Receiver<(PeerId, Stream)>,
+    receiver: InboundReceiver,
 }
 
 impl IncomingStreams {
-    pub(crate) fn new(receiver: mpsc::Receiver<(PeerId, Stream)>) -> Self {
-        Self { receiver }
+    pub(crate) fn new_bounded(receiver: mpsc::Receiver<(PeerId, Stream)>) -> Self {
+        Self {
+            receiver: InboundReceiver::Bounded(receiver),
+        }
+    }
+
+    pub(crate) fn new_unbounded(receiver: mpsc::UnboundedReceiver<(PeerId, Stream)>) -> Self {
+        Self {
+            receiver: InboundReceiver::Unbounded(receiver),
+        }
     }
 }
 

--- a/protocols/stream/src/shared.rs
+++ b/protocols/stream/src/shared.rs
@@ -9,15 +9,19 @@ use libp2p_identity::PeerId;
 use libp2p_swarm::{ConnectionId, Stream, StreamProtocol};
 use rand::seq::IteratorRandom as _;
 
-use crate::{handler::NewStream, AlreadyRegistered, IncomingStreams};
+use crate::{
+    control::{InboundSender, TrySendResult},
+    handler::NewStream,
+    AlreadyRegistered, IncomingStreams,
+};
 
 pub(crate) struct Shared {
     /// Tracks the supported inbound protocols created via
     /// [`Control::accept`](crate::Control::accept).
     ///
-    /// For each [`StreamProtocol`], we hold the [`mpsc::Sender`] corresponding to the
-    /// [`mpsc::Receiver`] in [`IncomingStreams`].
-    supported_inbound_protocols: HashMap<StreamProtocol, mpsc::Sender<(PeerId, Stream)>>,
+    /// For each [`StreamProtocol`], we hold the [`InboundSender`] corresponding to the
+    /// [`InboundReceiver`] in [`IncomingStreams`].
+    supported_inbound_protocols: HashMap<StreamProtocol, InboundSender>,
 
     connections: HashMap<ConnectionId, PeerId>,
     senders: HashMap<ConnectionId, mpsc::Sender<NewStream>>,
@@ -53,6 +57,15 @@ impl Shared {
         &mut self,
         protocol: StreamProtocol,
     ) -> Result<IncomingStreams, AlreadyRegistered> {
+        self.accept_with_limit(protocol, Some(0))
+    }
+
+    /// Allows communication channels with max(0, limit-1) number of buffered messages or an unbound channel
+    pub(crate) fn accept_with_limit(
+        &mut self,
+        protocol: StreamProtocol,
+        limit: Option<usize>,
+    ) -> Result<IncomingStreams, AlreadyRegistered> {
         self.supported_inbound_protocols
             .retain(|_, sender| !sender.is_closed());
 
@@ -60,11 +73,21 @@ impl Shared {
             return Err(AlreadyRegistered);
         }
 
-        let (sender, receiver) = mpsc::channel(0);
-        self.supported_inbound_protocols
-            .insert(protocol.clone(), sender);
-
-        Ok(IncomingStreams::new(receiver))
+        match limit {
+            None => {
+                let (sender, receiver) = mpsc::unbounded();
+                self.supported_inbound_protocols
+                    .insert(protocol.clone(), InboundSender::Unbounded(sender));
+                Ok(IncomingStreams::new_unbounded(receiver))
+            }
+            Some(limit) => {
+                let buffer = limit.saturating_sub(1);
+                let (sender, receiver) = mpsc::channel(buffer);
+                self.supported_inbound_protocols
+                    .insert(protocol.clone(), InboundSender::Bounded(sender));
+                Ok(IncomingStreams::new_bounded(receiver))
+            }
+        }
     }
 
     /// Lists the protocols for which we have an active [`IncomingStreams`] instance.
@@ -83,15 +106,14 @@ impl Shared {
     ) {
         match self.supported_inbound_protocols.entry(protocol.clone()) {
             Entry::Occupied(mut entry) => match entry.get_mut().try_send((remote, stream)) {
-                Ok(()) => {}
-                Err(e) if e.is_full() => {
+                TrySendResult::Ok => {}
+                TrySendResult::Full => {
                     tracing::debug!(%protocol, "Channel is full, dropping inbound stream");
                 }
-                Err(e) if e.is_disconnected() => {
+                TrySendResult::Disconnected => {
                     tracing::debug!(%protocol, "Channel is gone, dropping inbound stream");
                     entry.remove();
                 }
-                _ => unreachable!(),
             },
             Entry::Vacant(_) => {
                 tracing::debug!(%protocol, "channel is gone, dropping inbound stream");

--- a/protocols/stream/tests/lib.rs
+++ b/protocols/stream/tests/lib.rs
@@ -27,8 +27,11 @@ async fn dropping_incoming_streams_deregisters() {
     let mut swarm2 = Swarm::new_ephemeral_tokio(|_| stream::Behaviour::new());
 
     let mut control = swarm1.behaviour().new_control();
-    let mut incoming = swarm2.behaviour().new_control().accept(PROTOCOL).unwrap();
-
+    let mut incoming = swarm2
+        .behaviour()
+        .new_control()
+        .accept(PROTOCOL)
+        .unwrap();
     swarm2.listen().with_memory_addr_external().await;
     swarm1.connect(&mut swarm2).await;
 


### PR DESCRIPTION
Provide a way to define the channel size during  stream `accept` call.