### PR TITLE
allow for transport adapters

### DIFF
--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -5,6 +5,7 @@ mod behaviour;
 mod build;
 mod dns;
 mod identity;
+mod map_transport;
 mod other_transport;
 mod provider;
 mod quic;

--- a/libp2p/src/builder/phase/bandwidth_metrics.rs
+++ b/libp2p/src/builder/phase/bandwidth_metrics.rs
@@ -16,18 +16,12 @@ impl<T: AuthenticatedMultiplexedTransport, Provider, R>
         self,
         registry: &mut libp2p_metrics::Registry,
     ) -> SwarmBuilder<Provider, BehaviourPhase<impl AuthenticatedMultiplexedTransport, R>> {
-        SwarmBuilder {
-            phase: BehaviourPhase {
-                relay_behaviour: self.phase.relay_behaviour,
-                transport: libp2p_metrics::BandwidthTransport::new(self.phase.transport, registry)
-                    .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn))),
-            },
-            cert_chain: self.cert_chain,
-            private_key: self.private_key,
-            ca_certs: self.ca_certs,
-            crls: self.crls,
-            phantom: PhantomData,
-        }
+        self
+            .map_transport(|t| {
+                libp2p_metrics::BandwidthTransport::new(t, registry)
+                    .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn)))
+            })
+            .without_bandwidth_metrics()
     }
 }
 

--- a/libp2p/src/builder/phase/map_transport.rs
+++ b/libp2p/src/builder/phase/map_transport.rs
@@ -1,0 +1,195 @@
+use std::marker::PhantomData;
+
+use super::*;
+use crate::SwarmBuilder;
+
+impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, QuicPhase<T>> {
+    /// Map the current transport to another transport.
+    ///
+    /// This is a low-level escape hatch primarily intended for custom adapters, or
+    /// instrumentation/telemetry layers. Prefer the
+    /// dedicated builder helpers (like `with_bandwidth_metrics`)
+    /// where possible.
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, QuicPhase<impl AuthenticatedMultiplexedTransport>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: QuicPhase {
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport>
+    SwarmBuilder<Provider, OtherTransportPhase<T>>
+{
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, OtherTransportPhase<impl AuthenticatedMultiplexedTransport>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: OtherTransportPhase {
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, DnsPhase<T>> {
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, DnsPhase<impl AuthenticatedMultiplexedTransport>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: DnsPhase {
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, WebsocketPhase<T>> {
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, WebsocketPhase<impl AuthenticatedMultiplexedTransport>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: WebsocketPhase {
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, RelayPhase<T>> {
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, RelayPhase<impl AuthenticatedMultiplexedTransport>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: RelayPhase {
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport, R>
+    SwarmBuilder<Provider, BandwidthMetricsPhase<T, R>>
+{
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, BandwidthMetricsPhase<impl AuthenticatedMultiplexedTransport, R>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: BandwidthMetricsPhase {
+                relay_behaviour: self.phase.relay_behaviour,
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport, R>
+    SwarmBuilder<Provider, BehaviourPhase<T, R>>
+{
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, BehaviourPhase<impl AuthenticatedMultiplexedTransport, R>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: BehaviourPhase {
+                relay_behaviour: self.phase.relay_behaviour,
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}
+
+impl<Provider, T: AuthenticatedMultiplexedTransport, B> SwarmBuilder<Provider, SwarmPhase<T, B>> {
+    pub fn map_transport<U, F>(
+        self,
+        f: F,
+    ) -> SwarmBuilder<Provider, SwarmPhase<impl AuthenticatedMultiplexedTransport, B>>
+    where
+        U: AuthenticatedMultiplexedTransport,
+        F: FnOnce(T) -> U,
+    {
+        SwarmBuilder {
+            cert_chain: self.cert_chain,
+            private_key: self.private_key,
+            ca_certs: self.ca_certs,
+            crls: self.crls,
+            phantom: PhantomData,
+            phase: SwarmPhase {
+                behaviour: self.phase.behaviour,
+                transport: f(self.phase.transport),
+            },
+        }
+    }
+}


### PR DESCRIPTION
Introduce a `map_transport` method across all builder phases, providing a low-level mechanism to transform the underlying transport. This enables the insertion of custom adapters, instrumentation, or telemetry layers without having to fork or duplicate existing builder logic. The existing bandwidth metrics integration has been refactored to make use of this abstraction.